### PR TITLE
Add namespaces support

### DIFF
--- a/selectel/service_types.go
+++ b/selectel/service_types.go
@@ -1,7 +1,9 @@
 package selectel
 
 const (
-	DBaaS = "managed-database"
-	MKS   = "managed-kubernetes"
-	CRaaS = "container-registry"
+	DBaaS              = "managed-database"
+	MKS                = "managed-kubernetes"
+	CRaaS              = "container-registry"
+	SecretsManager     = "secrets-manager"
+	CertificateManager = "certificate-manager"
 )


### PR DESCRIPTION
Add SecretsManager `resource`s support management in different namespaces.
```hcl
provider "selectel" {
  ...
  auth_url    = "https://namespace/example/auth/v228"
  auth_region = "kr-1"
}
```